### PR TITLE
Add docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 .classpath
 .DS_Store
 **/*.DS_Store
+**/server.log

--- a/initial-example-app/.gitignore
+++ b/initial-example-app/.gitignore
@@ -1,0 +1,8 @@
+/RUNNING_PID
+logs/
+project/*-shim.sbt
+project/project/
+project/target/
+target/
+.idea/
+*.iml

--- a/initial-example-app/docker-build.sh
+++ b/initial-example-app/docker-build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sbt clean docker:publishLocal

--- a/initial-example-app/docker-compose.yml
+++ b/initial-example-app/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+
+services:
+  postgres:
+    image: postgres:latest
+    container_name: postgres
+    environment:
+      - "TZ=Europe/Amsterdam"        
+      - "POSTGRES_USER=docker"
+      - "POSTGRES_PASSWORD=docker"
+    ports:
+      - "5432:5432"
+    volumes:
+      - "./sql:/docker-entrypoint-initdb.d"

--- a/initial-example-app/docker-compose.yml
+++ b/initial-example-app/docker-compose.yml
@@ -12,3 +12,14 @@ services:
       - "5432:5432"
     volumes:
       - "./sql:/docker-entrypoint-initdb.d"
+
+  bookstore:
+    image: initial-example-server:latest
+    container_name: bookstore
+    environment:
+      - "TZ=Europe/Amsterdam"
+      - "DATABASE_USER=docker"
+      - "DATABASE_PASSWORD=docker"
+      - "DATABASE_URL=jdbc:postgresql://postgres:5432/akkaexampleapp"
+    ports:
+      - "8080:8080"

--- a/initial-example-app/docker-run.sh
+++ b/initial-example-app/docker-run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker rm -f $(docker ps -aq)
+docker run -d -p 8080:8080 initial-example-server:latest

--- a/initial-example-app/launch.sh
+++ b/initial-example-app/launch.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose up -d

--- a/initial-example-app/launch.sh
+++ b/initial-example-app/launch.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+docker rm -f $(docker ps -aq)
 docker-compose up -d

--- a/initial-example-app/project/plugins.sbt
+++ b/initial-example-app/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "0.8.0-M1")
+addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "1.1.0")

--- a/initial-example-app/psql-cli.sh
+++ b/initial-example-app/psql-cli.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo "==================     Help for psql    ========================="
+echo "\l or \list                : shows all databases"
+echo "\d                         : shows all tables, views and sequences"
+echo "\dn                        : shows all schemas"
+echo "\d table_name              : describe table, view, sequence, or index"
+echo "\c database_name           : connect to a database"
+echo "\q                         : quit"
+echo "\?                         : for more commands"
+echo "====================    Extensions    ==========================="
+echo "create extension pgcrypto; : installs cryptographic functions"
+echo "====================    Some SQL    ============================="
+echo "select gen_random_uuid();  : returns a random uuid (pgcrypto)"
+echo "select version();          : return the server version"
+echo "select current_date;       : returns the current date"
+echo "================================================================="
+docker exec -it postgres psql --dbname=akkaexampleapp --username=docker

--- a/initial-example-app/readme.md
+++ b/initial-example-app/readme.md
@@ -1,0 +1,25 @@
+# initial-example-app
+Example code from the Mastering Akka book
+
+# How to build
+To build and package the bookstore example as a docker application, run the script `docker-build.sh`. This script
+will instruct sbt to build the application, package the application and build a docker image, tag it and store
+it in the local docker repository.
+
+To launch the project which includes launching the bookstore example and the postgres database including provisioning it
+with a schema run the script `launch.sh`. 
+
+When docker has been installed on OSX for example, using Virtualbox, a virtual machine should be available on the 
+default IP address: 192.168.99.100, which is simple to give an alias by adding the following line to your /etc/hosts file:
+
+```
+192.168.99.100 boot2docker
+```
+
+Now you can reference the docker environment in the URL by `boot2docker` instead of the ip address. 
+
+To create a user, simply do:
+
+```
+http -v post boot2docker:8080/api/user firstName=Chris lastName=Baxter email=chris@masteringakka.com
+```

--- a/initial-example-app/server/src/main/resources/application.conf
+++ b/initial-example-app/server/src/main/resources/application.conf
@@ -12,8 +12,11 @@ bookstore{
     numThreads = 10
     driver = "org.postgresql.Driver"
     url = "jdbc:postgresql://localhost:5432/akkaexampleapp"
+    url = ${?DATABASE_URL}
     user = "root"
+    user = ${?DATABASE_USER}
     password = ""
+    password = ${?DATABASE_PASSWORD}
     connectionTestQuery = "select 1"
   } 
 }

--- a/initial-example-app/server/src/main/resources/logback.xml
+++ b/initial-example-app/server/src/main/resources/logback.xml
@@ -1,22 +1,29 @@
 <configuration debug="true">
-  
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+      </Pattern>
+    </layout>
+  </appender>
 
     <!-- The catch all logger that will receive everything (except the access log data) -->
-  <appender name="serverLog" class="ch.qos.logback.core.rolling.RollingFileAppender" level="ERROR">
-    <file>server.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-	    <fileNamePattern>server.%d{yyyy-MM-dd}.log</fileNamePattern>
-	    <maxHistory>30</maxHistory>
-    </rollingPolicy>        
-    <append>true</append>
-    <encoder>
-      <pattern>%d [%thread] %-5level %logger{35} - %msg%n</pattern>
-      <immediateFlush>true</immediateFlush>
-    </encoder>
-  </appender> 
-  
-  <root>
-    <appender-ref ref="serverLog" />
+  <!--<appender name="serverLog" class="ch.qos.logback.core.rolling.RollingFileAppender" level="ERROR">-->
+    <!--<file>server.log</file>-->
+    <!--<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">-->
+	    <!--<fileNamePattern>server.%d{yyyy-MM-dd}.log</fileNamePattern>-->
+	    <!--<maxHistory>30</maxHistory>-->
+    <!--</rollingPolicy>        -->
+    <!--<append>true</append>-->
+    <!--<encoder>-->
+      <!--<pattern>%d [%thread] %-5level %logger{35} - %msg%n</pattern>-->
+      <!--<immediateFlush>true</immediateFlush>-->
+    <!--</encoder>-->
+  <!--</appender> -->
+  <!---->
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
   </root>
   
 </configuration>


### PR DESCRIPTION
Docker leads to a much smoother developer experience and is an easy way to deploy micro services, why not use it in our developer workflow. I have added support for it in the project by configuring sbt to use the native packager and added some scripts so that docker-compose can be instructed to launch the bookstore example. I know some parts of  the first chapter should be rewritten so that the docker can be incorporated. Its up to you to opt-in or out of this idea. 
